### PR TITLE
fastcdr and fastrtps are not anymore available in the defined branch

### DIFF
--- a/meta-ros2-humble/generated-recipes/fastcdr/fastcdr_1.0.26-3.bb
+++ b/meta-ros2-humble/generated-recipes/fastcdr/fastcdr_1.0.26-3.bb
@@ -40,8 +40,11 @@ DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS}"
 RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
 
 # matches with: https://github.com/ros2-gbp/fastcdr-release/archive/release/rolling/fastcdr/1.0.26-3.tar.gz
+# 05042024: the needed SHA is not available in the ROS_BRANCH anymore
+# so using nobranch=1 temporarily
+NO_BRANCH ?= "nobranch=1"
 ROS_BRANCH ?= "branch=release/rolling/fastcdr"
-SRC_URI = "git://github.com/ros2-gbp/fastcdr-release;${ROS_BRANCH};protocol=https"
+SRC_URI = "git://github.com/ros2-gbp/fastcdr-release;${NO_BRANCH};protocol=https"
 SRCREV = "12f4509d762a21934db6946e3acfa20883e99070"
 S = "${WORKDIR}/git"
 

--- a/meta-ros2-humble/generated-recipes/fastrtps/fastrtps_2.10.1-1.bb
+++ b/meta-ros2-humble/generated-recipes/fastrtps/fastrtps_2.10.1-1.bb
@@ -56,8 +56,11 @@ DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS}"
 RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
 
 # matches with: https://github.com/ros2-gbp/fastrtps-release/archive/release/rolling/fastrtps/2.10.1-1.tar.gz
+# 05042024: the needed SHA is not available in the ROS_BRANCH anymore
+# so using nobranch=1 temporarily
+NO_BRANCH ?= "nobranch=1"
 ROS_BRANCH ?= "branch=release/rolling/fastrtps"
-SRC_URI = "git://github.com/ros2-gbp/fastrtps-release;${ROS_BRANCH};protocol=https"
+SRC_URI = "git://github.com/ros2-gbp/fastrtps-release;${NO_BRANCH};protocol=https"
 SRCREV = "57bbde99931362c75f2a97a69d893c5abd174e90"
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
use nobranch=1 option to fetch commit from outside of branch
Do we want to use the dangling commit or have it cherry-picked to existing branch?